### PR TITLE
Individual Packages version can be specified by step name or package id

### DIFF
--- a/src/main/java/com/octopusdeploy/api/DeploymentsApi.java
+++ b/src/main/java/com/octopusdeploy/api/DeploymentsApi.java
@@ -136,8 +136,9 @@ public class DeploymentsApi {
         for (Object pkgObj : pkgsJson) {
             JSONObject pkgJsonObj = (JSONObject) pkgObj;
             String name = pkgJsonObj.getString("StepName");
+            String packageId = pkgJsonObj.getString("PackageId");
             String version = pkgJsonObj.getString("VersionSelectedLastRelease");
-            packages.add(new SelectedPackage(name, version));
+            packages.add(new SelectedPackage(name, packageId, version));
         }
 
         DeploymentProcessTemplate template = new DeploymentProcessTemplate(deploymentId, projectId, packages);

--- a/src/main/java/com/octopusdeploy/api/data/SelectedPackage.java
+++ b/src/main/java/com/octopusdeploy/api/data/SelectedPackage.java
@@ -4,24 +4,28 @@ package com.octopusdeploy.api.data;
  * Represents a SelectedPackage, part of a Release.
  */
 public class SelectedPackage {
-    private final String stepName;
+
+    private String stepName;
     public String getStepName() {
         return stepName;
     }
+    public void setStepName(String stepName) { this.stepName = stepName; }
+
+    private final String packageId;
+    public String getPackageId() { return packageId; }
     
     private final String version;
-    public String getVersion() {
-        return version;
-    }
-    
-    public SelectedPackage(String stepName, String version) {
+    public String getVersion() { return version; }
+
+    public SelectedPackage(String stepName, String packageId, String version) {
         this.stepName = stepName;
+        this.packageId = packageId;
         this.version = version;
     }
 
     @Override
     public String toString() {
-        return "SelectedPackage [stepName=" + stepName + ", version=" + version + "]";
+        return "SelectedPackage [stepName=" + stepName + ", packageId=" + packageId + ", version=" + version + "]";
     }
 
 }


### PR DESCRIPTION
Emulates same behaviour as octo.client where individual packages version can be specified by step name or packageid. https://octopus.com/docs/api-and-integration/octo.exe-command-line/creating-releases