### PR TITLE
Move documentation into the GitHub repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ THE SOFTWARE.
   <artifactId>octopusdeploy</artifactId>
   <version>1.10.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/OctopusDeploy+Plugin</url>
+  <url>https://github.com/jenkinsci/octopusdeploy-plugin</url>
 
   <scm>
     <connection>scm:git:https://github.com/jenkinsci/octopusdeploy-plugin.git</connection>


### PR DESCRIPTION
Migrate docs from Wiki to GitHub.  The README in the repository is already at least as good as the information that was previously stored in the wiki.  The https://plugins.jenkins.io/octopusdeploy/ page already links to the README.  The next release after this is merged will cause the contents of the README to be displayed directly on the https://plugins.jenkins.io/octopusdeploy/ page.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
